### PR TITLE
Update README badges to api.runelite.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gauntlet Minimap v1.2 [![Plugin Installs](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/gauntlet-minimap&label=Active%20installs)](https://runelite.net/plugin-hub/Vic%20Segers) [![Plugin Rank](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/rank/plugin/gauntlet-minimap)](https://runelite.net/plugin-hub)
+# Gauntlet Minimap v1.2 [![Plugin Installs](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/gauntlet-minimap&label=Active%20installs)](https://runelite.net/plugin-hub/Vic%20Segers) [![Plugin Rank](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/gauntlet-minimap)](https://runelite.net/plugin-hub)
 
 ## Description
 


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/gauntlet-minimap) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart: